### PR TITLE
fix if the options is not given(undefiend) when the HLCServer is instanced

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,6 +43,7 @@ var DEFAULT_PROTECTED_REQUESTS = [
 function HLCServer(options) {
   var self = this;
   
+  options = options || {};
   parseOptions(self, options);
 
   self.app = express();
@@ -200,8 +201,6 @@ HLCServer.prototype.addNotificationService = function(options) {
  * @param {Object} options The options as a JSON object.
  */
 function parseOptions(instance, options) {
-  options = options || {};
-
   instance.httpPort = options.httpPort || HTTP_PORT;
   instance.useCors = options.useCors || USE_CORS;
   instance.password = options.password || DEFAULT_PASSWORD;


### PR DESCRIPTION
I just run the hlc-server without any options given, as the example code provided.
![screen shot 2015-10-26 at 23 27 01](https://cloud.githubusercontent.com/assets/1693027/10744281/1794b61a-7c39-11e5-990e-afaff77391fe.png)

But i got this error as below:

![screen shot 2015-10-26 at 23 26 36](https://cloud.githubusercontent.com/assets/1693027/10744270/04de9a04-7c39-11e5-9608-f4eee45b1808.png)

so i checked the source code, found if the options object is not given, which means it's undefined. then the `options` variable in `parseOptions` function should have no reference with the parameter `options` passed in.
so the statement:

```
options = options || {};
```

will create a new reference to the {} object and has no more relation with the `options` passed in.

So i moved this statement above, before the `parseOptions` function runs.

Should work now even if the options object is not given when the hlc-server is instanced.
